### PR TITLE
fix: 修复 log() 输出到 stdout 导致命令替换捕获日志内容的问题

### DIFF
--- a/tproxy.sh
+++ b/tproxy.sh
@@ -98,10 +98,10 @@ log() {
             ;;
     esac
 
-    if [ -t 1 ]; then
-        printf "%b\n" "${color_code}${timestamp} [${level}]: ${message}\033[0m"
+    if [ -t 2 ]; then
+        printf "%b\n" "${color_code}${timestamp} [${level}]: ${message}\033[0m" >&2
     else
-        printf "%s\n" "${timestamp} [${level}]: ${message}"
+        printf "%s\n" "${timestamp} [${level}]: ${message}" >&2
     fi
 }
 


### PR DESCRIPTION
函数将日志输出到 stdout，当在命令替换 `$()` 中调用包含 log 语句的函数时，日志内容会被一并捕获到变量中。

find_packages_uid 内部调用了 log Debug，导致 $uids 变量不仅包含 UID 列表，还包含了日志输出，造成后续 iptables 规则添加错误。