### PR TITLE
fix: 修复分应用代理 UID 解析失败的问题

### DIFF
--- a/tproxy.sh
+++ b/tproxy.sh
@@ -2,7 +2,7 @@
 
 readonly SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -P)"
 # Version (use YY.MM.DD format)
-readonly SCRIPT_VERSION="v26.02.09"
+readonly SCRIPT_VERSION="v26.02.18"
 
 # Configuration (modify as needed)
 


### PR DESCRIPTION
- find_packages_uid 调用时去掉引号，避免整个包名列表被当作单个参数传入
- 修复 whitelist 模式下误用 BYPASS_APPS_LIST 的 bug，改为正确的 PROXY_APPS_LIST