### PR TITLE
fix(tproxy): 修复黑名单应用 TCP 连接被 RST 的问题

### DIFF
--- a/tproxy.sh
+++ b/tproxy.sh
@@ -2,7 +2,7 @@
 
 readonly SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -P)"
 # Version (use YY.MM.DD format)
-readonly SCRIPT_VERSION="v26.02.18"
+readonly SCRIPT_VERSION="v26.02.18.1"
 
 # Configuration (modify as needed)
 


### PR DESCRIPTION
-m socket 缺少 --transparent 标志，导致被绕过应用的响应包
被 DIVERT 链错误标记并重路由至 TPROXY